### PR TITLE
Correção de campo poster_path não nulo

### DIFF
--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/data/model/ListStreamResponse.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/data/model/ListStreamResponse.kt
@@ -4,7 +4,7 @@ data class StreamResponse(
     val id : String,
     val title : String,
     val overview : String,
-    val poster_path: String,
+    val poster_path: String? = null,
 )
 data class ListStreamResponse(
     val results: List<StreamResponse>


### PR DESCRIPTION
## Descrição

O campo poster_path da data class StreamResponse estava setado como não nulo. Com isso, quando o atributo vinha nulo do serviço, o loading da tela recebia um erro.

## Testes Realizados

Validada a recepção dos dados com o campo nulo e o campo não nulo. Com o campo não nulo, as listas em carrossel são mostradas com sucesso na tela.

## Screenshots

![imagem_do_erro](https://github.com/CodandoTV/StreamPlayerApp/assets/30787731/04018a9d-0fec-4910-bec5-8b323ebbcdbd)


## Checklist

- [ ] Os testes foram executados e passaram com sucesso.
- [x] As alterações de código seguem as diretrizes de estilo do projeto.
- [ ] Foram adicionados testes, se aplicável.
- [x] Se inscreveu no canal?😛

## Issues Relacionadas

[Adicione as issues relacionadas a esse PR, se houver.]
- [link da issue 1]