### PR TITLE
corrige bug de scroll infinito na tela de detalhes

### DIFF
--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/screens/DetailStreamsScreen.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/screens/DetailStreamsScreen.kt
@@ -1,8 +1,8 @@
 package com.codandotv.streamplayerapp.feature_list_streams.detail.presentation.screens
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
@@ -40,7 +40,7 @@ fun DetailStreamScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(ScrollState(0))
+            .verticalScroll(rememberScrollState())
     ) {
         when (uiState) {
             is DetailStreamsLoadedUIState -> {

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/screens/DetailStreamsScreen.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/screens/DetailStreamsScreen.kt
@@ -37,16 +37,12 @@ fun DetailStreamScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     Lifecycle(lifecycleOwner, viewModel, disposable)
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-    ) {
-        when (uiState) {
-            is DetailStreamsLoadedUIState -> {
-                SetupDetailScreen(uiState as DetailStreamsLoadedUIState, navController)
-            }
-            else -> {
+    when (uiState) {
+        is DetailStreamsLoadedUIState -> {
+            SetupDetailScreen(uiState as DetailStreamsLoadedUIState, navController)
+        }
+        else -> {
+            Box(Modifier.fillMaxSize()) {
                 CircularProgressIndicator(
                     modifier = Modifier.align(
                         Alignment.Center
@@ -54,6 +50,7 @@ fun DetailStreamScreen(
                 )
             }
         }
+
     }
 }
 
@@ -63,69 +60,75 @@ fun DetailStreamScreen(
 private fun SetupDetailScreen(
     uiState: DetailStreamsLoadedUIState, navController: NavController
 ) {
-    Scaffold(topBar = {
-        DetailStreamToolbar(navController = navController)
-    }, content = { innerPadding ->
-        Column(
-            Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-        ) {
-            DetailStreamImagePreview(uiState)
+    Scaffold(
+        topBar = {
+            DetailStreamToolbar(navController = navController)
+        },
+        content = { innerPadding ->
             Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(start = 16.dp, end = 16.dp, top = 8.dp)
+                Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(innerPadding)
             ) {
-                DetailStreamRowHeader()
-                Text(
-                    text = uiState.detailStream.title,
-                    style = MaterialTheme.typography.headlineMedium.copy(
-                        fontWeight = FontWeight.Bold, fontSize = 28.sp
+                DetailStreamImagePreview(uiState)
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp, top = 8.dp)
+                ) {
+                    DetailStreamRowHeader()
+                    Text(
+                        text = uiState.detailStream.title,
+                        style = MaterialTheme.typography.headlineMedium.copy(
+                            fontWeight = FontWeight.Bold, fontSize = 28.sp
+                        )
                     )
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = uiState.detailStream.releaseYear,
-                    style = MaterialTheme.typography.headlineMedium.copy(
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontSize = 14.sp, fontWeight = FontWeight.Bold
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = uiState.detailStream.releaseYear,
+                        style = MaterialTheme.typography.headlineMedium.copy(
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 14.sp, fontWeight = FontWeight.Bold
+                        )
                     )
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                DetailStreamButtonAction(
-                    buttonsColors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.surface
-                    ),
-                    imageVector = Icons.Filled.PlayArrow,
-                    imageVectorColor = MaterialTheme.colorScheme.onSurface,
-                    text = stringResource(R.string.detail_watch_primary_button),
-                    textColor = MaterialTheme.colorScheme.onSurface,
-                    onClick = {},
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                DetailStreamButtonAction(
-                    buttonsColors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.onSurfaceVariant
-                    ),
-                    imageVector = Icons.Filled.FileDownload,
-                    imageVectorColor = MaterialTheme.colorScheme.onSurface,
-                    text = stringResource(id = R.string.detail_default_text_secondary_button),
-                    textColor = MaterialTheme.colorScheme.onSurface,
-                    onClick = {},
-                )
-                Text(
-                    text = uiState.detailStream.overview,
-                    style = MaterialTheme.typography.headlineMedium.copy(
-                        color = MaterialTheme.colorScheme.onSurface, fontSize = 16.sp, lineHeight = 1.25.em
-                    ),
-                    modifier = Modifier.padding(top = 8.dp, bottom = 16.dp)
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                DetailStreamActionOption()
+                    Spacer(modifier = Modifier.height(8.dp))
+                    DetailStreamButtonAction(
+                        buttonsColors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.surface
+                        ),
+                        imageVector = Icons.Filled.PlayArrow,
+                        imageVectorColor = MaterialTheme.colorScheme.onSurface,
+                        text = stringResource(R.string.detail_watch_primary_button),
+                        textColor = MaterialTheme.colorScheme.onSurface,
+                        onClick = {},
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    DetailStreamButtonAction(
+                        buttonsColors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.onSurfaceVariant
+                        ),
+                        imageVector = Icons.Filled.FileDownload,
+                        imageVectorColor = MaterialTheme.colorScheme.onSurface,
+                        text = stringResource(id = R.string.detail_default_text_secondary_button),
+                        textColor = MaterialTheme.colorScheme.onSurface,
+                        onClick = {},
+                    )
+                    Text(
+                        text = uiState.detailStream.overview,
+                        style = MaterialTheme.typography.headlineMedium.copy(
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontSize = 16.sp,
+                            lineHeight = 1.25.em
+                        ),
+                        modifier = Modifier.padding(top = 8.dp, bottom = 16.dp)
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    DetailStreamActionOption()
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
             }
-        }
-    })
+        })
 }
 
 @Composable

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsScreen.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsScreen.kt
@@ -1,9 +1,9 @@
 package com.codandotv.streamplayerapp.feature_list_streams.list.presentation.screens
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -76,7 +76,7 @@ fun ListStreamsScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .align(Alignment.TopCenter)
-                        .verticalScroll(ScrollState(0))
+                        .verticalScroll(rememberScrollState())
                 ) {
                     uiState.carousels.forEach {
                         StreamsCarousel(


### PR DESCRIPTION
## Descrição

- Adiciona `Modifier.verticalScroll` dentro de Scaffold para evitar scroll infinito
- Adiciona melhoria em scroll state para utilizar `rememberScrollState()`, pois mantém a instância do estado cacheada e também salva a posição caso ocorra `onConfigurationChanged`
- Aplica format code

## Screenshots

### Antes
[streamPlayerApp_infinite_scroll.webm](https://github.com/CodandoTV/StreamPlayerApp/assets/51065868/064c6890-44ba-4203-abd5-66176460b198)

### Depois

[streamPlayer_fix_scroll.webm](https://github.com/CodandoTV/StreamPlayerApp/assets/51065868/c92818cc-5920-4197-96a8-44429e84ac7b)

## Checklist

- [x] Os testes foram executados e passaram com sucesso.
- [x] As alterações de código seguem as diretrizes de estilo do projeto.
- [ ] Foram adicionados testes, se aplicável.
- [x] Se inscreveu no canal?😛
