### PR TITLE
[ISSUE-31] - Corrigindo tratamento do ciclo de vida do compose para chamar apenas 1x

### DIFF
--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/navigation/DetailStreamNavigation.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/navigation/DetailStreamNavigation.kt
@@ -1,5 +1,6 @@
 package com.codandotv.streamplayerapp.feature_list_streams.detail.presentation.navigation
 
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -16,7 +17,9 @@ internal const val DEFAULT_ID = "0"
 
 fun NavGraphBuilder.detailStreamNavGraph(navController: NavHostController) {
     composable(DETAIL_COMPLETE) { nav ->
-        loadKoinModules(DetailStreamModule.module)
+        if (nav.getLifecycle().currentState == Lifecycle.State.STARTED) {
+            loadKoinModules(DetailStreamModule.module)
+        }
         DetailStreamScreen(
             koinViewModel {
                 parametersOf(nav.arguments?.getString(ID) ?: DEFAULT_ID)

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/navigation/ListStreamsNavigation.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/navigation/ListStreamsNavigation.kt
@@ -1,6 +1,7 @@
 package com.codandotv.streamplayerapp.feature_list_streams.list.presentation.navigation
 
 import androidx.activity.compose.BackHandler
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -13,9 +14,11 @@ import org.koin.core.context.loadKoinModules
 import org.koin.core.context.unloadKoinModules
 
 fun NavGraphBuilder.listStreamsNavGraph(navController: NavHostController) {
-    composable(BottomNavRoutes.HOME) {
+    composable(BottomNavRoutes.HOME) { nav ->
         BackHandler(true) {}
-        loadKoinModules(ListStreamModule.module)
+        if (nav.getLifecycle().currentState == Lifecycle.State.STARTED) {
+            loadKoinModules(ListStreamModule.module)
+        }
         ListStreamsScreen(navController = navController,
             onNavigateDetailList = { id ->
                 navController.navigate("${DETAIL}${id}")


### PR DESCRIPTION
## Descrição

Durante a gravação do video do ciclo de vida descobri um problema na implementação no qual chamava várias vezes o loadmodules, não teria problema pq ele não vai substituir o mapa ja criado ali, porem é zuado deixar caindo várias vezes ate ter um comportamento não previsto

## Testes Realizados
testando aplicação
