### PR TITLE
[ISSUE-56] - Adicionando o token da API nas variáveis de Ambiente

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -11,5 +11,10 @@ object Config {
     object BuildField {
         const val host_debug = "\"https://api.themoviedb.org/3/\""
         const val host_release = "\"https://api.themoviedb.org/3/\""
+
+        private const val tmdb_env_name_debug = "TMDB_API_TOKEN_DEBUG"
+        private const val tmdb_env_name_release = "TMDB_API_TOKEN_RELEASE"
+        val api_auth_debug: String by lazy { "\"Bearer ${System.getenv(tmdb_env_name_debug) ?: ""}\"" }
+        val api_auth_release: String by lazy { "\"Bearer ${System.getenv(tmdb_env_name_release) ?: ""}\"" }
     }
 }

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -14,7 +14,7 @@ object Config {
 
         private const val tmdb_env_name_debug = "TMDB_API_TOKEN_DEBUG"
         private const val tmdb_env_name_release = "TMDB_API_TOKEN_RELEASE"
-        val api_auth_debug: String by lazy { "\"Bearer ${System.getenv(tmdb_env_name_debug) ?: ""}\"" }
-        val api_auth_release: String by lazy { "\"Bearer ${System.getenv(tmdb_env_name_release) ?: ""}\"" }
+        val api_auth_debug = "\"Bearer ${System.getenv(tmdb_env_name_debug) ?: ""}\""
+        val api_auth_release = "\"Bearer ${System.getenv(tmdb_env_name_release) ?: ""}\""
     }
 }

--- a/core-networking/build.gradle.kts
+++ b/core-networking/build.gradle.kts
@@ -1,12 +1,14 @@
-android{
+android {
     namespace = "${Config.packageName}core_networking"
 
-    buildTypes{
-        getByName("debug"){
-            buildConfigField("String","HOST",Config.BuildField.host_debug)
+    buildTypes {
+        getByName("debug") {
+            buildConfigField("String", "HOST", Config.BuildField.host_debug)
+            buildConfigField("String", "API_AUTH", Config.BuildField.api_auth_debug)
         }
-        getByName("release"){
-            buildConfigField("String","HOST",Config.BuildField.host_release)
+        getByName("release") {
+            buildConfigField("String", "HOST", Config.BuildField.host_release)
+            buildConfigField("String", "API_AUTH", Config.BuildField.api_auth_release)
         }
     }
 }

--- a/core-networking/src/main/java/com/codandotv/streamplayerapp/core_networking/di/NetworkModule.kt
+++ b/core-networking/src/main/java/com/codandotv/streamplayerapp/core_networking/di/NetworkModule.kt
@@ -31,7 +31,7 @@ object NetworkModule {
                         .newBuilder()
                         .addHeader(
                             "Authorization",
-                            "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJiNDg2NWM4YTAzNzhmM2I4NjI0OWU1ZjNiYWFiMjU2NyIsInN1YiI6IjY0Mjk4YTg5YTNlNGJhMWM0NDgzM2U4OCIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.9cIxv29vkaZ2yW88DIFRUFK_nXbK2b6KS8t96kA8WAE"
+                            BuildConfig.API_AUTH
                         )
                         .addHeader("Content-Type", "application/json;charset=utf-8")
                         .build()


### PR DESCRIPTION
## Descrição
Nesta PR removemos o token da API do TMDB, que estava fixo no código, e passamos a obtê-lo das variáveis de ambiente.

OBS:
- Duas variáveis de ambiente estão sendo lidas no intuito de haver uma para cada ambiente de deploy (debug, release);
- Existe uma breaking change neste PR, assim que o merge acontecer será obrigatório que todos que queiram buildar o app tenham os seus próprios tokens e os registrem nas variáveis de ambiente;
- Uma documentação para auxiliar na criação do token e das variáveis de ambiente está sendo desenvolvida, esta será adicionada na wiki do projeto.


## Testes Realizados
Os testes foram realizados constatando o valor da campo de configuração através do debug, rodando a aplicação e avaliando o logcat.

## Checklist

- [x] Os testes foram executados e passaram com sucesso.
- [x] As alterações de código seguem as diretrizes de estilo do projeto.
- [ ] Foram adicionados testes, se aplicável.
- [x] Se inscreveu no canal?😛

## Issues Relacionadas
[Remover API token hard coded para usar alguma variável de ambiente](https://github.com/CodandoTV/StreamPlayerApp/issues/56) #56