### PR TITLE
[ISSUE-66] - Melhorias sobre o BottomBar

### DIFF
--- a/app/src/main/java/com/codandotv/streamplayerapp/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/codandotv/streamplayerapp/navigation/NavigationGraph.kt
@@ -1,34 +1,51 @@
 package com.codandotv.streamplayerapp.navigation
 
 import android.annotation.SuppressLint
+import android.app.Activity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.codandotv.streamplayerapp.core_navigation.bottomnavigation.StreamPlayerBottomNavigation
-import com.codandotv.streamplayerapp.core_navigation.routes.BottomNavRoutes
+import com.codandotv.streamplayerapp.core_navigation.helper.currentRoute
 import com.codandotv.streamplayerapp.core_navigation.routes.Routes
 import com.codandotv.streamplayerapp.feature_list_streams.detail.presentation.navigation.detailStreamNavGraph
 import com.codandotv.streamplayerapp.feature_list_streams.list.presentation.navigation.listStreamsNavGraph
 import com.codandotv.streamplayerapp.splah.presentation.navigation.splashNavGraph
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NavigationGraph(navController: NavHostController) {
-    NavHost(navController = navController, startDestination = Routes.Splash) {
-        splashNavGraph(navController = navController)
-        listStreamsNavGraph(navController = navController)
-        detailStreamNavGraph(navController = navController)
-        temporaryFun(BottomNavRoutes.GAMES, navController)
-        temporaryFun(BottomNavRoutes.NEWS, navController)
-        temporaryFun(BottomNavRoutes.SCENES, navController)
-        temporaryFun(BottomNavRoutes.DOWNLOADS, navController)
+    Scaffold(bottomBar = {
+        if(Routes.hasBottomBar(currentRoute(navController = navController))) {
+            StreamPlayerBottomNavigation(navController = navController)
+        }
+    }) { paddingValues ->
+        Box(modifier = Modifier.padding(paddingValues)) {
+            NavHost(navController = navController, startDestination = Routes.Splash.route) {
+                splashNavGraph(navController = navController)
+                listStreamsNavGraph(navController = navController)
+                detailStreamNavGraph(navController = navController)
+                temporaryFun(Routes.Games.route, navController)
+                temporaryFun(Routes.News.route, navController)
+                temporaryFun(Routes.Scenes.route, navController)
+                temporaryFun(Routes.Downloads.route, navController)
+            }
+        }
     }
 }
 
@@ -42,11 +59,7 @@ fun NavGraphBuilder.temporaryFun(route: String, navController: NavController) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun example(navController: NavController, route: String) {
-    Scaffold(
-        bottomBar = {
-            StreamPlayerBottomNavigation(navController = navController)
-        }
-    ) { _ ->
+    Scaffold { _ ->
         Text(text = route, color = Color.White)
     }
 }

--- a/app/src/main/java/com/codandotv/streamplayerapp/splah/presentation/navigation/SplashNavigation.kt
+++ b/app/src/main/java/com/codandotv/streamplayerapp/splah/presentation/navigation/SplashNavigation.kt
@@ -3,14 +3,13 @@ package com.codandotv.streamplayerapp.splah.presentation.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
-import com.codandotv.streamplayerapp.core_navigation.routes.BottomNavRoutes
 import com.codandotv.streamplayerapp.core_navigation.routes.Routes
 import com.codandotv.streamplayerapp.splah.presentation.screens.SplashScreen
 
 fun NavGraphBuilder.splashNavGraph(navController: NavHostController) {
-    composable(Routes.Splash) {
+    composable(Routes.Splash.route) {
         SplashScreen(
-            onAnimationFinished = { navController.navigate(BottomNavRoutes.HOME) }
+            onAnimationFinished = { navController.navigate(Routes.Home.route) }
         )
     }
 }

--- a/core-navigation/src/main/java/com/codandotv/streamplayerapp/core_navigation/bottomnavigation/BottomNavItem.kt
+++ b/core-navigation/src/main/java/com/codandotv/streamplayerapp/core_navigation/bottomnavigation/BottomNavItem.kt
@@ -3,7 +3,7 @@ package com.codandotv.streamplayerapp.core_navigation.bottomnavigation
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.codandotv.streamplayerapp.core_navigation.R
-import com.codandotv.streamplayerapp.core_navigation.routes.BottomNavRoutes
+import com.codandotv.streamplayerapp.core_navigation.routes.Routes
 
 sealed class BottomNavItem(
     @StringRes var title: Int,
@@ -16,7 +16,7 @@ sealed class BottomNavItem(
             R.string.bottom_nav_home,
             R.drawable.ic_home_unselected,
             R.drawable.ic_home_selected,
-            BottomNavRoutes.HOME
+            Routes.Home.route
         )
 
     object Games :
@@ -24,7 +24,7 @@ sealed class BottomNavItem(
             R.string.bottom_nav_games,
             R.drawable.ic_games_unselected,
             R.drawable.ic_games_selected,
-            BottomNavRoutes.GAMES
+            Routes.Games.route
         )
 
     object News :
@@ -32,13 +32,13 @@ sealed class BottomNavItem(
             R.string.bottom_nav_news,
             R.drawable.ic_news_unselected,
             R.drawable.ic_news_selected,
-            BottomNavRoutes.NEWS
+            Routes.News.route
         )
 
     object Downloads : BottomNavItem(
         R.string.bottom_nav_downloads,
         R.drawable.ic_downloads_unselected,
         R.drawable.ic_downloads_selected,
-        BottomNavRoutes.DOWNLOADS
+        Routes.Downloads.route
     )
 }

--- a/core-navigation/src/main/java/com/codandotv/streamplayerapp/core_navigation/bottomnavigation/StreamPlayerBottomNavigation.kt
+++ b/core-navigation/src/main/java/com/codandotv/streamplayerapp/core_navigation/bottomnavigation/StreamPlayerBottomNavigation.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.codandotv.streamplayerapp.core_navigation.helper.currentRoute
+import com.codandotv.streamplayerapp.core_navigation.routes.Routes
 
 private val bottomMenuItems = listOf(
     BottomNavItem.Home,

--- a/core-navigation/src/main/java/com/codandotv/streamplayerapp/core_navigation/helper/NavigationHelper.kt
+++ b/core-navigation/src/main/java/com/codandotv/streamplayerapp/core_navigation/helper/NavigationHelper.kt
@@ -6,7 +6,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 
 @Composable
-fun currentRoute(navController: NavController): String? {
+fun currentRoute(navController: NavController): String {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
-    return navBackStackEntry?.destination?.route
+    return navBackStackEntry?.destination?.route ?: ""
 }

--- a/core-navigation/src/main/java/com/codandotv/streamplayerapp/core_navigation/routes/BottomNavRoutes.kt
+++ b/core-navigation/src/main/java/com/codandotv/streamplayerapp/core_navigation/routes/BottomNavRoutes.kt
@@ -1,9 +1,0 @@
-package com.codandotv.streamplayerapp.core_navigation.routes
-
-object BottomNavRoutes {
-    const val HOME = "bottomHome"
-    const val GAMES = "bottomGames"
-    const val NEWS = "bottomNews"
-    const val SCENES = "bottomScenes"
-    const val DOWNLOADS = "bottomDownloads"
-}

--- a/core-navigation/src/main/java/com/codandotv/streamplayerapp/core_navigation/routes/Routes.kt
+++ b/core-navigation/src/main/java/com/codandotv/streamplayerapp/core_navigation/routes/Routes.kt
@@ -2,10 +2,26 @@ package com.codandotv.streamplayerapp.core_navigation.routes
 
 import com.codandotv.streamplayerapp.core_navigation.routes.Routes.PARAM.ID
 
-object Routes {
-    const val DETAIL = "DetailList/"
-    const val DETAIL_COMPLETE = "${DETAIL}{${ID}}"
-    const val Splash = "splash"
+enum class Routes(
+    val route: String,
+    val hasBottomBar: Boolean = true,
+) {
+    Detail(route = "detailsList/", hasBottomBar = false),
+    DetailComplete(route = "${Detail.route}{${ID}}", hasBottomBar = false),
+    Splash(route = "splash", hasBottomBar = false),
+    Home(route = "home"),
+    Games(route = "games"),
+    News(route = "news"),
+    Scenes(route = "scenes"),
+    Downloads(route = "downloads");
+
+    companion object {
+        fun hasBottomBar(route: String): Boolean {
+            return Routes.values().find {
+                it.route == route && it.hasBottomBar
+            } != null
+        }
+    }
 
     object PARAM {
         const val ID = "id"

--- a/core-shared-ui/src/main/res/values-v31/themes.xml
+++ b/core-shared-ui/src/main/res/values-v31/themes.xml
@@ -5,5 +5,6 @@
         <item name="android:statusBarColor">@color/black</item>
         <item name="android:windowBackground">@color/black</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/transparent_image</item>
+        <item name="android:navigationBarColor">@color/black</item>
     </style>
 </resources>

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/navigation/DetailStreamNavigation.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/navigation/DetailStreamNavigation.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
-import com.codandotv.streamplayerapp.core_navigation.routes.Routes.DETAIL_COMPLETE
+import com.codandotv.streamplayerapp.core_navigation.routes.Routes
 import com.codandotv.streamplayerapp.core_navigation.routes.Routes.PARAM.ID
 import com.codandotv.streamplayerapp.feature_list_streams.detail.di.DetailStreamModule
 import com.codandotv.streamplayerapp.feature_list_streams.detail.presentation.screens.DetailStreamScreen
@@ -16,7 +16,7 @@ import org.koin.core.parameter.parametersOf
 internal const val DEFAULT_ID = "0"
 
 fun NavGraphBuilder.detailStreamNavGraph(navController: NavHostController) {
-    composable(DETAIL_COMPLETE) { nav ->
+    composable(Routes.DetailComplete.route) { nav ->
         if (nav.getLifecycle().currentState == Lifecycle.State.STARTED) {
             loadKoinModules(DetailStreamModule.module)
         }

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/navigation/ListStreamsNavigation.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/navigation/ListStreamsNavigation.kt
@@ -6,22 +6,21 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
-import com.codandotv.streamplayerapp.core_navigation.routes.BottomNavRoutes
-import com.codandotv.streamplayerapp.core_navigation.routes.Routes.DETAIL
+import com.codandotv.streamplayerapp.core_navigation.routes.Routes
 import com.codandotv.streamplayerapp.feature_list_streams.list.di.ListStreamModule
 import com.codandotv.streamplayerapp.feature_list_streams.list.presentation.screens.ListStreamsScreen
 import org.koin.core.context.loadKoinModules
 import org.koin.core.context.unloadKoinModules
 
 fun NavGraphBuilder.listStreamsNavGraph(navController: NavHostController) {
-    composable(BottomNavRoutes.HOME) { nav ->
+    composable(Routes.Home.route) { nav ->
         BackHandler(true) {}
         if (nav.getLifecycle().currentState == Lifecycle.State.STARTED) {
             loadKoinModules(ListStreamModule.module)
         }
-        ListStreamsScreen(navController = navController,
+        ListStreamsScreen(
             onNavigateDetailList = { id ->
-                navController.navigate("${DETAIL}${id}")
+                navController.navigate("${Routes.Detail.route}${id}")
             }, disposable = {
                 unloadKoinModules(ListStreamModule.module)
             })

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsScreen.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsScreen.kt
@@ -32,7 +32,6 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 fun ListStreamsScreen(
     viewModel: ListStreamViewModel = koinViewModel(),
-    navController: NavController,
     onNavigateDetailList: (String) -> Unit = {},
     disposable: () -> Unit = {}
 ) {
@@ -58,9 +57,6 @@ fun ListStreamsScreen(
         topBar = {
             StreamPlayerTopBar(scrollBehavior)
         },
-        bottomBar = {
-            StreamPlayerBottomNavigation(navController = navController)
-        }
     ) { _ ->
         Box(
             modifier = Modifier
@@ -100,5 +96,5 @@ fun ListStreamsScreen(
 @ThemePreviews
 @Composable
 fun ListStreamsScreenPreview() {
-    ListStreamsScreen(navController = rememberNavController())
+    ListStreamsScreen()
 }


### PR DESCRIPTION
## Descrição

Esta pr melhora o BottomBar removendo a sobreposição da sobre os últimos itens na tela de lista e evitar o efeito fade-in como se ela fosse recriada e todas as telas.

## Testes Realizados

Os testes foram realizados rodando o aplicativo num dispositivo físico e verificando se não quebrou nada pelos logs

## Screenshots

- Antes

https://github.com/CodandoTV/StreamPlayerApp/assets/45848094/5da10cba-63dc-4f9b-a160-d98947f28e56



- Depois


https://github.com/CodandoTV/StreamPlayerApp/assets/45848094/917468ba-b3c7-4d8f-9270-0996dddc075b


## Checklist

- [x] Os testes foram executados e passaram com sucesso.
- [x] As alterações de código seguem as diretrizes de estilo do projeto.
- [ ] Foram adicionados testes, se aplicável.
- [x] Se inscreveu no canal?😛

## Issues Relacionadas

- ![ Remover sobreposição da barra de navegação sobre os últimos itens na tela de lista #66 ](https://github.com/CodandoTV/StreamPlayerApp/issues/66)