### PR TITLE
[ISSUE-57][ISSUE-70] - Compatibilizando o token de autenticação

### DIFF
--- a/build-logic/src/main/java/Keys.kt
+++ b/build-logic/src/main/java/Keys.kt
@@ -1,0 +1,12 @@
+object Keys {
+    private const val default_tmdb_token = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJiNDg2NWM4YTAzNzhmM2I4NjI0OWU1ZjNiYWFiMjU2NyIsInN1YiI6IjY0Mjk4YTg5YTNlNGJhMWM0NDgzM2U4OCIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.9cIxv29vkaZ2yW88DIFRUFK_nXbK2b6KS8t96kA8WAE"
+    private const val tmdb_token_name_debug = "TMDB_BEARER_TOKEN_DEBUG"
+    private const val tmdb_token_name_release = "TMDB_BEARER_TOKEN_RELEASE"
+
+    object BuildField {
+        val api_bearer_debug =
+            "\"Bearer ${System.getenv(tmdb_token_name_debug) ?: default_tmdb_token}\""
+        val api_bearer_release =
+            "\"Bearer ${System.getenv(tmdb_token_name_release) ?: default_tmdb_token}\""
+    }
+}

--- a/core-networking/build.gradle.kts
+++ b/core-networking/build.gradle.kts
@@ -1,13 +1,15 @@
 plugins {
     id("com.streamplayer.android-library")
 }
-android{
-    buildTypes{
-        getByName("debug"){
-            buildConfigField("String","HOST",Config.BuildField.host_debug)
+android {
+    buildTypes {
+        getByName("debug") {
+            buildConfigField("String", "HOST", Config.BuildField.host_debug)
+            buildConfigField("String", "API_BEARER_AUTH", Keys.BuildField.api_bearer_debug)
         }
-        getByName("release"){
-            buildConfigField("String","HOST",Config.BuildField.host_release)
+        getByName("release") {
+            buildConfigField("String", "HOST", Config.BuildField.host_release)
+            buildConfigField("String", "API_BEARER_AUTH", Keys.BuildField.api_bearer_release)
         }
     }
 }

--- a/core-networking/build.gradle.kts
+++ b/core-networking/build.gradle.kts
@@ -3,11 +3,11 @@ plugins {
 }
 android {
     buildTypes {
-        getByName("debug") {
+        debug {
             buildConfigField("String", "HOST", Config.BuildField.host_debug)
             buildConfigField("String", "API_BEARER_AUTH", Keys.BuildField.api_bearer_debug)
         }
-        getByName("release") {
+        release {
             buildConfigField("String", "HOST", Config.BuildField.host_release)
             buildConfigField("String", "API_BEARER_AUTH", Keys.BuildField.api_bearer_release)
         }

--- a/core-networking/src/main/java/com/codandotv/streamplayerapp/core_networking/di/NetworkModule.kt
+++ b/core-networking/src/main/java/com/codandotv/streamplayerapp/core_networking/di/NetworkModule.kt
@@ -31,7 +31,7 @@ object NetworkModule {
                         .newBuilder()
                         .addHeader(
                             "Authorization",
-                            "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJiNDg2NWM4YTAzNzhmM2I4NjI0OWU1ZjNiYWFiMjU2NyIsInN1YiI6IjY0Mjk4YTg5YTNlNGJhMWM0NDgzM2U4OCIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.9cIxv29vkaZ2yW88DIFRUFK_nXbK2b6KS8t96kA8WAE"
+                            BuildConfig.API_BEARER_AUTH
                         )
                         .addHeader("Content-Type", "application/json;charset=utf-8")
                         .build()


### PR DESCRIPTION
## Descrição
Adicionamos a possibilidade do usuário fornecer um token de autenticação próprio através das variáveis de ambiente.
Caso o usuário não adicione essa variável de ambiente utilizamos um token padrão fornecido pelo @rviannaoliveira 

OBS: Esse PR precisa ser mergeado antes do [[ISSUE-57] - Colocando Catalogs no projeto](https://github.com/CodandoTV/StreamPlayerApp/pull/61) #61 

## Testes Realizados
Os testes foram realizados constatando o valor da campo de configuração através do debug, rodando a aplicação e avaliando o logcat.

## Checklist

- [x] Os testes foram executados e passaram com sucesso.
- [x] As alterações de código seguem as diretrizes de estilo do projeto.
- [ ] Foram adicionados testes, se aplicável.
- [x] Se inscreveu no canal?😛

## Issues Relacionadas
[Compatibilizar token de autenticação com os catalogs no gradle](https://github.com/CodandoTV/StreamPlayerApp/issues/70) #70
[Colocar catalogs no build gradle](https://github.com/CodandoTV/StreamPlayerApp/issues/57) #57 