### PR TITLE
[ISSUE-72] - Mantendo paginas já carregadas após recomposição

### DIFF
--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsScreen.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsScreen.kt
@@ -83,10 +83,9 @@ fun ListStreamsScreen(
 
                     HighlightBanner(data = uiState.highlightBanner)
 
-                    uiState.genres.forEach { genre ->
+                    uiState.streamsCarouselContent.forEach { streamCarouselContent ->
                         StreamsCarousel(
-                            title = genre.name,
-                            contentList = viewModel.loadMovies(genre),
+                            content = streamCarouselContent,
                             onNavigateDetailList = onNavigateDetailList,
                         )
                         Spacer(modifier = Modifier.height(12.dp))

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsUIState.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsUIState.kt
@@ -1,10 +1,10 @@
 package com.codandotv.streamplayerapp.feature_list_streams.list.presentation.screens
 
-import com.codandotv.streamplayerapp.feature_list_streams.list.domain.model.Genre
 import com.codandotv.streamplayerapp.feature_list_streams.list.domain.model.HighlightBanner
+import com.codandotv.streamplayerapp.feature_list_streams.list.presentation.widgets.StreamsCarouselContent
 
 data class ListStreamsUIState(
     val highlightBanner: HighlightBanner? = null,
-    val genres: List<Genre>,
+    val streamsCarouselContent: List<StreamsCarouselContent>,
     val isLoading: Boolean
 )

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/widgets/StreamsCarousel.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/widgets/StreamsCarousel.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -23,21 +22,23 @@ import androidx.paging.compose.itemKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
+data class StreamsCarouselContent(
+    val genreTitle: String,
+    val contentList: Flow<PagingData<StreamsCardContent>>
+)
+
 @Composable
 fun StreamsCarousel(
-    title: String,
-    contentList: Flow<PagingData<StreamsCardContent>>,
+    content: StreamsCarouselContent,
     modifier: Modifier = Modifier,
     onNavigateDetailList: (String) -> Unit = {},
 ) {
-    val flow = remember { contentList }
-
-    val lazyPagingItems = flow.collectAsLazyPagingItems()
+    val lazyPagingItems = content.contentList.collectAsLazyPagingItems()
     val lazyListState = rememberLazyListState()
 
     Column(modifier = modifier) {
         Text(
-            title,
+            content.genreTitle,
             style = MaterialTheme.typography.headlineMedium.copy(
                 fontWeight = FontWeight.Bold,
                 fontSize = 20.sp
@@ -73,7 +74,9 @@ fun StreamsCarousel(
 @Preview
 fun StreamsCarouselPreview() {
     StreamsCarousel(
-        title = "Ação",
-        contentList = emptyFlow()
+        content = StreamsCarouselContent(
+            genreTitle = "Ação",
+            contentList = emptyFlow()
+        )
     )
 }


### PR DESCRIPTION
## Descrição
### Passos para reproduzir o problema:
- Rolar alguma seção (stream carousel) várias vezes;
- Selecionar o stream para acessar a tela de detalhes;
- Voltar da tela de detalhes para a tela anterior.

### Resultado Atual
- Posição do **scroll do carousel** fica no início da lista, pois a lista foi recarregada.

### Resultado Esperado
- Posição do **scroll do carousel** tem que estar aonde o usuário deixou;

## Checklist

- [ ] Os testes foram executados e passaram com sucesso.
- [x] As alterações de código seguem as diretrizes de estilo do projeto.
- [ ] Foram adicionados testes, se aplicável.
- [x] Se inscreveu no canal?😛

## Issues Relacionadas
- Issue https://github.com/CodandoTV/StreamPlayerApp/issues/72