### PR TITLE
[ISSUE-66]: fix - Sobreposição de itens pelo bottomBar

### DIFF
--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsScreen.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsScreen.kt
@@ -61,9 +61,10 @@ fun ListStreamsScreen(
         bottomBar = {
             StreamPlayerBottomNavigation(navController = navController)
         }
-    ) { _ ->
+    ) { paddingValues ->
         Box(
             modifier = Modifier
+                .padding(paddingValues)
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
         ) {


### PR DESCRIPTION
## Descrição
Corrigindo sobreposição do ultimo carrossel de imagens pelo bottomBar.

Aplicado o `paddingValues` do Scaffold na Box que contém a lista principal de itens, com isso o bottomBar agora é desenhado abaixo da do último carrossel de filmes sem sobrepô-los.

## Testes Realizados
Teste com código antigo e novo realizados em um dispositivo físico, o resultado pode ser conferido nos vídeos abaixo


## Screenshots
### Antes:
https://github.com/CodandoTV/StreamPlayerApp/assets/35709152/329db5fe-55b6-41ed-8c8f-2712e60ee028


### Agora:
https://github.com/CodandoTV/StreamPlayerApp/assets/35709152/ca461aa9-63d2-4935-ab37-8eefb1c4051e



## Checklist

- [x] Os testes foram executados e passaram com sucesso.
- [x] As alterações de código seguem as diretrizes de estilo do projeto.
- [ ] Foram adicionados testes, se aplicável.
- [x] Se inscreveu no canal?😛

## Issues Relacionadas

Corrigi o bug relatado na issue #66 