### PR TITLE
[ISSUE-97] - Add new lifecycleEffect

### DIFF
--- a/build-logic/src/main/java/Config.kt
+++ b/build-logic/src/main/java/Config.kt
@@ -1,8 +1,8 @@
 object Config {
     const val applicationId = "com.codandotv.streamplayerapp"
-    const val compileSdkVersion = 33
+    const val compileSdkVersion = 34
     const val minSdkVersion = 24
-    const val targetSdkVersion = 33
+    const val targetSdkVersion = 34
     const val versionName = "1.0"
     const val versionCode = 1
     const val testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/screens/DetailStreamViewModel.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/screens/DetailStreamViewModel.kt
@@ -1,17 +1,13 @@
 package com.codandotv.streamplayerapp.feature_list_streams.detail.presentation.screens
 
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.codandotv.streamplayerapp.core_networking.handleError.catchFailure
 import com.codandotv.streamplayerapp.feature_list_streams.detail.domain.DetailStream
 import com.codandotv.streamplayerapp.feature_list_streams.detail.domain.DetailStreamUseCase
+import com.codandotv.streamplayerapp.feature_list_streams.detail.domain.VideoStreamsUseCase
 import com.codandotv.streamplayerapp.feature_list_streams.detail.presentation.screens.DetailStreamsUIState.DetailStreamsLoadedUIState
 import com.codandotv.streamplayerapp.feature_list_streams.detail.presentation.screens.DetailStreamsUIState.LoadingStreamUIState
-import kotlinx.coroutines.flow.*
-import com.codandotv.streamplayerapp.feature_list_streams.detail.domain.VideoStreamsUseCase
-import com.codandotv.streamplayerapp.feature_list_streams.detail.presentation.screens.DetailStreamsUIState.*
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -23,11 +19,11 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.zip
 import kotlinx.coroutines.launch
 
-class DetailStreamViewModel(
+class  DetailStreamViewModel(
     private val detailStreamUseCase: DetailStreamUseCase,
     private val videoStreamsUseCase: VideoStreamsUseCase,
     private val dispatcher: CoroutineDispatcher
-) : ViewModel(), DefaultLifecycleObserver {
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow<DetailStreamsUIState>(LoadingStreamUIState)
     val uiState: StateFlow<DetailStreamsUIState> = _uiState.stateIn(
@@ -36,9 +32,7 @@ class DetailStreamViewModel(
         initialValue = _uiState.value
     )
 
-    override fun onCreate(owner: LifecycleOwner) {
-        super.onCreate(owner)
-
+    fun loadDetail() {
         viewModelScope.launch {
             detailStreamUseCase.getMovie()
                 .zip(videoStreamsUseCase.getVideoStreams()) { detailStream, videoUrl ->

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/screens/DetailStreamsScreen.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/detail/presentation/screens/DetailStreamsScreen.kt
@@ -17,7 +17,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.codandotv.streamplayerapp.core_shared_ui.widget.SharingStreamCustomView
@@ -37,7 +39,25 @@ fun DetailStreamScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     val lifecycleOwner = LocalLifecycleOwner.current
-    Lifecycle(lifecycleOwner, viewModel, disposable)
+
+    LifecycleEventEffect(Lifecycle.Event.ON_START) {
+        viewModel.loadDetail()
+    }
+
+//    //Or you can use directly
+//    LifecycleStartEffect(Unit){
+//        viewModel.loadDetail()
+//
+//        this.onStopOrDispose {
+//
+//        }
+//    }
+
+    DisposableEffect(lifecycleOwner) {
+        onDispose {
+            disposable.invoke()
+        }
+    }
 
     when (uiState) {
         is DetailStreamsLoadedUIState -> {
@@ -48,6 +68,7 @@ fun DetailStreamScreen(
                 onNavigateSearchScreen = onNavigateSearchScreen
             )
         }
+
         else -> {
             Box(Modifier.fillMaxSize()) {
                 CircularProgressIndicator(
@@ -147,7 +168,10 @@ private fun SetupDetailScreen(
                         modifier = Modifier.padding(top = 8.dp, bottom = 16.dp)
                     )
                     Spacer(modifier = Modifier.height(8.dp))
-                    DetailStreamActionOption(uiState.detailStream, onToggleToMyList, { showDialog.value = true })
+                    DetailStreamActionOption(
+                        uiState.detailStream,
+                        onToggleToMyList,
+                        { showDialog.value = true })
                     Spacer(modifier = Modifier.height(16.dp))
                 }
             }
@@ -167,21 +191,4 @@ private fun SetupDetailScreen(
                 }
             }
         })
-}
-
-@Composable
-private fun Lifecycle(
-    lifecycleOwner: LifecycleOwner, viewModel: DetailStreamViewModel, disposable: () -> Unit
-) {
-    
-    DisposableEffect(lifecycleOwner) {
-        val lifecycle = lifecycleOwner.lifecycle
-
-        lifecycle.addObserver(viewModel)
-
-        onDispose {
-            lifecycle.removeObserver(viewModel)
-            disposable.invoke()
-        }
-    }
 }

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamViewModel.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamViewModel.kt
@@ -1,6 +1,5 @@
 package com.codandotv.streamplayerapp.feature_list_streams.list.presentation.screens
 
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
@@ -32,7 +31,7 @@ class ListStreamViewModel(
     private val listStreams: ListStreamUseCase,
     private val listGenres: GetGenresUseCase,
     private val latestStream: GetTopRatedStream
-) : ViewModel(), DefaultLifecycleObserver {
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(
         ListStreamsUIState(

--- a/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsScreen.kt
+++ b/feature-list-streams/src/main/java/com/codandotv/streamplayerapp/feature_list_streams/list/presentation/screens/ListStreamsScreen.kt
@@ -46,12 +46,7 @@ fun ListStreamsScreen(
     val baseScrollState = rememberScrollState()
 
     DisposableEffect(lifecycleOwner) {
-        val lifecycle = lifecycleOwner.lifecycle
-
-        lifecycle.addObserver(viewModel)
-
         onDispose {
-            lifecycle.removeObserver(viewModel)
             disposable.invoke()
         }
     }

--- a/feature-list-streams/src/test/java/com/codandotv/streamplayerapp/feature_list_streams/detail/DetailStreamViewModelTest.kt
+++ b/feature-list-streams/src/test/java/com/codandotv/streamplayerapp/feature_list_streams/detail/DetailStreamViewModelTest.kt
@@ -10,7 +10,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -21,7 +20,6 @@ class DetailStreamViewModelTest {
     private lateinit var detailStreamViewModel: DetailStreamViewModel
     private lateinit var detailUseCase: DetailStreamUseCase
     private lateinit var videoUseCase: VideoStreamsUseCase
-    private lateinit var lifecycleOwner: LifecycleOwner
 
     @get:Rule
     val rule = InstantTaskExecutorRule()
@@ -33,7 +31,6 @@ class DetailStreamViewModelTest {
     fun setUp() {
         detailUseCase = mockk()
         videoUseCase = mockk()
-        lifecycleOwner = mockk()
 
         detailStreamViewModel = DetailStreamViewModel(
             detailStreamUseCase = detailUseCase,
@@ -48,7 +45,7 @@ class DetailStreamViewModelTest {
             coEvery { detailUseCase.getMovie() } returns flowOf(detailStream)
             coEvery { videoUseCase.getVideoStreams() } returns flowOf(videosStreamsList)
 
-            detailStreamViewModel.onCreate(lifecycleOwner)
+            detailStreamViewModel.loadDetail()
 
             coVerify {
                 detailStreamViewModel.uiState.value.let {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ compose_material_3 = "1.0.1"
 compose_activity = "1.5.0"
 compose_icons = "1.4.3"
 compose_navigation = "2.5.3"
-lifecycle_compose_runtime = "2.6.1"
+lifecycle_version = "2.7.0"
 compose_pagging="1.0.0-alpha20"
 
 coil = "2.3.0"
@@ -95,7 +95,7 @@ compose_bom = { group = "androidx.compose", name = "compose-bom", version.ref = 
 compose_ui = { module = "androidx.compose.ui:ui" }
 compose_toolingpreview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose_icons = { module = "androidx.compose.material:material-icons-extended" }
-compose_lifecycle = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle_compose_runtime" }
+compose_lifecycle = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle_version" }
 compose_material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "compose_material_3" }
 compose_navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "compose_navigation" }
 compose_pagging = { group = "androidx.paging", name = "paging-compose", version.ref = "compose_pagging" }


### PR DESCRIPTION
## Descrição
Update `lifecycle-runtime-compose` to 2.7.0 to use the new approach to use `LifecycleEvent`

Remove unnecessary `DefaultLifecycleObserver` in ViewModel

https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0-rc02

This PR will close:
- https://github.com/CodandoTV/streamPlayerApp/issues/97

![Captura de Tela 2024-01-22 às 17 27 45](https://github.com/CodandoTV/StreamPlayerApp/assets/7690931/b681b8c4-6330-446f-b171-97930fb76c1e)
